### PR TITLE
ci: Don't persist user cred when git checkout so semantic release can…

### DIFF
--- a/.github/workflows/semantic-version.yml
+++ b/.github/workflows/semantic-version.yml
@@ -17,6 +17,7 @@ jobs:
               uses: actions/checkout@v3
               with:
                   fetch-depth: 0
+                  persist-credentials: false
             - name: Setup Node.js
               uses: actions/setup-node@v3
               with:


### PR DESCRIPTION
… trigger action with the SEMANTIC_TOKEN